### PR TITLE
feat: add entrypoint

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .gitignore
-.github/
+/.github/
+/.idea/
 README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
 FROM alpine:3.21.0 AS builder
 
 RUN apk add --no-cache \
-    curl \
-    tar \
-    jq
+    curl
 
 RUN curl -fsSLO https://github.com/digitalocean/doctl/releases/download/v1.120.0/doctl-1.120.0-linux-amd64.tar.gz && \
     tar -xf doctl-1.120.0-linux-amd64.tar.gz && \
     chmod +x doctl && \
-    mv doctl /usr/local/bin
+    mv doctl /tmp/doctl
+
+RUN curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz && \
+    tar -xf helm.tar.gz && \
+    chmod +x linux-amd64/helm && \
+    mv linux-amd64/helm /tmp/helm
+
+COPY ./entrypoint.sh /tmp/entrypoint.sh
+RUN chmod +x /tmp/entrypoint.sh
 
 FROM alpine:3.21.0
 
 RUN apk add --no-cache \
+    bash \
     curl \
     jq
 
-COPY ./aliases.sh /etc/profile.d/aliases.sh
+COPY --from=builder /tmp/doctl /usr/local/bin/doctl
+COPY --from=builder /tmp/helm /usr/local/bin/helm
+COPY --from=builder /tmp/entrypoint.sh /entrypoint.sh
 
-COPY --from=builder /usr/local/bin/doctl /usr/local/bin/doctl
-
-CMD ["/bin/sh", "-l"]
+RUN touch /etc/tracker-tv-do.conf
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,23 +1,9 @@
 # do
 
-This is the `do` (Digital Ocean) image which contains some tools:
+This is the Digital Ocean image, it's intended to be used as a helper image for CI/CD pipelines.
+
+## Tools
 
 - `doctl`
+- `helm`
 - `jq`
-
-## Usage
-
-You need to have a `doctl` configuration file:  
-- On linux the configuration file is located at `~/.config/doctl/config.yaml`.  
-- On OSX the configuration file is located at `/Users/$USER/Library/Application Support/doctl/config.yaml`.
-
-### Linux
-
-```bash
-docker run --rm -it -v $HOME/.config/doctl/config.yaml:/root/doctl/config.yaml ghcr.io/tracker-tv/do-amd64:latest
-```
-
-### OSX
-```bash
-docker run --rm -it -v /Users/$USER/Library/Application\ Support/doctl/config.yaml:/root/doctl/config.yaml ghcr.io/tracker-tv/do-arm64:latest
-```

--- a/aliases.sh
+++ b/aliases.sh
@@ -1,1 +1,0 @@
-alias doctl="doctl --config /root/doctl/config.yaml"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec "$@"


### PR DESCRIPTION
This pull request includes several changes to improve the Docker setup and update the documentation for the Digital Ocean helper image. The most important changes include updates to the `.dockerignore` file, modifications to the `Dockerfile` to add new tools and streamline the build process, and updates to the `README.md` to reflect the new tools and usage instructions.

### Docker setup improvements:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5L2-R3): Added `.github/` and `.idea/` directories to the ignore list.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L4-R31): Removed unnecessary packages from the builder stage, added `helm` tool, and changed the entrypoint setup.
* [`entrypoint.sh`](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2R1-R3): Added a new entrypoint script to execute commands.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-L23): Updated the description and tools section, removed outdated usage instructions.

### Code cleanup:

* [`aliases.sh`](diffhunk://#diff-b22d34cb5065a20df5df57fc795e53d721fcd17815bb29accdc98e05ac3a5f76L1): Removed the alias for `doctl` as it's no longer needed.