### PR TITLE
feat: add docker and use ubuntu image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.21.0 AS builder
+FROM ubuntu:22.04 AS builder
 
-RUN apk add --no-cache \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl
 
 RUN curl -fsSLO https://github.com/digitalocean/doctl/releases/download/v1.120.0/doctl-1.120.0-linux-amd64.tar.gz && \
@@ -16,12 +16,13 @@ RUN curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.g
 COPY ./entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 
-FROM alpine:3.21.0
+FROM ubuntu:22.04
 
-RUN apk add --no-cache \
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     bash \
     curl \
-    jq
+    jq \
+    docker.io
 
 COPY --from=builder /tmp/doctl /usr/local/bin/doctl
 COPY --from=builder /tmp/helm /usr/local/bin/helm


### PR DESCRIPTION
This pull request includes significant changes to the `Dockerfile` to update the base image and package management system. The most important changes include switching the base image from Alpine to Ubuntu and updating the package installation commands accordingly.

Updates to the Dockerfile:

* Changed the base image from `alpine:3.21.0` to `ubuntu:22.04` for both the builder and final stages.
* Updated the package installation commands from `apk` to `apt-get`, including necessary updates and installations.
* Added the installation of `docker.io` to the final stage of the Dockerfile.