### PR TITLE
feat: separate arch in different Dockerfile

### DIFF
--- a/.github/workflows/do.yml
+++ b/.github/workflows/do.yml
@@ -31,6 +31,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: Dockerfile
+          file: Dockerfile.${{ matrix.architecture }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ github.repository }}-${{matrix.architecture}}:latest

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,0 +1,37 @@
+FROM ubuntu:22.04 AS builder
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    curl
+
+RUN curl -fsSLO https://github.com/digitalocean/doctl/releases/download/v1.120.0/doctl-1.120.0-linux-amd64.tar.gz && \
+    tar -xf doctl-1.120.0-linux-amd64.tar.gz && \
+    chmod +x doctl && \
+    mv doctl /tmp/doctl
+
+RUN curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl && \
+    chmod +x kubectl && \
+    mv kubectl /tmp/kubectl
+
+RUN curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz && \
+    tar -xf helm.tar.gz && \
+    chmod +x linux-amd64/helm && \
+    mv linux-amd64/helm /tmp/helm
+
+COPY ./entrypoint.sh /tmp/entrypoint.sh
+RUN chmod +x /tmp/entrypoint.sh
+
+FROM ubuntu:22.04
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    bash \
+    curl \
+    jq \
+    docker.io
+
+COPY --from=builder /tmp/doctl /usr/local/bin/doctl
+COPY --from=builder /tmp/kubectl /usr/local/bin/kubectl
+COPY --from=builder /tmp/helm /usr/local/bin/helm
+COPY --from=builder /tmp/entrypoint.sh /entrypoint.sh
+
+RUN touch /etc/tracker-tv-do.conf
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,22 +1,26 @@
-FROM ubuntu:22.04 AS builder
+FROM arm64v8/ubuntu AS builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl
 
-RUN curl -fsSLO https://github.com/digitalocean/doctl/releases/download/v1.120.0/doctl-1.120.0-linux-amd64.tar.gz && \
-    tar -xf doctl-1.120.0-linux-amd64.tar.gz && \
+RUN curl -fsSLO https://github.com/digitalocean/doctl/releases/download/v1.120.0/doctl-1.120.0-linux-arm64.tar.gz && \
+    tar -xf doctl-1.120.0-linux-arm64.tar.gz && \
     chmod +x doctl && \
     mv doctl /tmp/doctl
 
-RUN curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.gz && \
+RUN curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/arm64/kubectl && \
+    chmod +x kubectl && \
+    mv kubectl /tmp/kubectl
+
+RUN curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-v3.16.4-linux-arm64.tar.gz && \
     tar -xf helm.tar.gz && \
-    chmod +x linux-amd64/helm && \
-    mv linux-amd64/helm /tmp/helm
+    chmod +x linux-arm64/helm && \
+    mv linux-arm64/helm /tmp/helm
 
 COPY ./entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 
-FROM ubuntu:22.04
+FROM arm64v8/ubuntu
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     bash \
@@ -25,6 +29,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && 
     docker.io
 
 COPY --from=builder /tmp/doctl /usr/local/bin/doctl
+COPY --from=builder /tmp/kubectl /usr/local/bin/kubectl
 COPY --from=builder /tmp/helm /usr/local/bin/helm
 COPY --from=builder /tmp/entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This pull request introduces support for building Docker images for multiple architectures by updating the workflow and adding a new Dockerfile for the ARM64 architecture. The most important changes include modifying the workflow to use architecture-specific Dockerfiles, updating the existing Dockerfile for AMD64, and adding a new Dockerfile for ARM64.

### Workflow updates:

* `.github/workflows/do.yml`: Modified the workflow to use architecture-specific Dockerfiles by changing the `file` parameter to `Dockerfile.${{ matrix.architecture }}`.

### Dockerfile updates:

* `Dockerfile.amd64`: Added commands to download and install `kubectl`, and updated the COPY command to include `kubectl`.
* `Dockerfile.arm64`: Added a new Dockerfile for the ARM64 architecture, including commands to download and install `doctl`, `kubectl`, and `helm`, and updated the COPY commands to include these binaries.