### PR TITLE
chore: update ubuntu image

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS builder
+FROM ubuntu:24.10 AS builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl
@@ -20,7 +20,7 @@ RUN curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.g
 COPY ./entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 
-FROM ubuntu:22.04
+FROM ubuntu:24.10
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     bash \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu AS builder
+FROM arm64v8/ubuntu:24.10 AS builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl
@@ -20,7 +20,7 @@ RUN curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-v3.16.4-linux-arm64.tar.g
 COPY ./entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 
-FROM arm64v8/ubuntu
+FROM arm64v8/ubuntu:24.10
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     bash \


### PR DESCRIPTION
This pull request updates the base images used in the Dockerfiles for both amd64 and arm64 architectures. The main changes include updating the Ubuntu version to 24.10 and ensuring compatibility with the new version.

### Dockerfile updates:

* `Dockerfile.amd64`: Updated the base image from `ubuntu:22.04` to `ubuntu:24.10` to ensure compatibility with the latest Ubuntu release.
* `Dockerfile.arm64`: Updated the base image from `arm64v8/ubuntu` to `arm64v8/ubuntu:24.10` to align with the latest Ubuntu release for ARM architecture.