### PR TITLE
feat: add ytt

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -17,6 +17,10 @@ RUN curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-v3.16.4-linux-amd64.tar.g
     chmod +x linux-amd64/helm && \
     mv linux-amd64/helm /tmp/helm
 
+RUN curl -LO https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.51.1/ytt-linux-amd64 && \
+    chmod +x ytt-linux-amd64 && \
+    mv ytt-linux-amd64 /tmp/ytt
+
 COPY ./entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 
@@ -31,6 +35,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && 
 COPY --from=builder /tmp/doctl /usr/local/bin/doctl
 COPY --from=builder /tmp/kubectl /usr/local/bin/kubectl
 COPY --from=builder /tmp/helm /usr/local/bin/helm
+COPY --from=builder /tmp/ytt /usr/local/bin/ytt
 COPY --from=builder /tmp/entrypoint.sh /entrypoint.sh
 
 RUN touch /etc/tracker-tv-do.conf

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -17,6 +17,10 @@ RUN curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-v3.16.4-linux-arm64.tar.g
     chmod +x linux-arm64/helm && \
     mv linux-arm64/helm /tmp/helm
 
+RUN curl -LO https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.51.1/ytt-linux-arm64 && \
+    chmod +x ytt-linux-arm64 && \
+    mv ytt-linux-arm64 /tmp/ytt
+
 COPY ./entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 
@@ -31,6 +35,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && 
 COPY --from=builder /tmp/doctl /usr/local/bin/doctl
 COPY --from=builder /tmp/kubectl /usr/local/bin/kubectl
 COPY --from=builder /tmp/helm /usr/local/bin/helm
+COPY --from=builder /tmp/ytt /usr/local/bin/ytt
 COPY --from=builder /tmp/entrypoint.sh /entrypoint.sh
 
 RUN touch /etc/tracker-tv-do.conf


### PR DESCRIPTION
This pull request includes updates to the Dockerfiles for both amd64 and arm64 architectures to add the `ytt` tool from VMware Tanzu Carvel. The most important changes include downloading, setting executable permissions, and moving the `ytt` binary to the appropriate directory, as well as copying the `ytt` binary to the final image.

### Additions to Dockerfiles:

* `Dockerfile.amd64`: Added commands to download `ytt`, make it executable, and move it to `/tmp/ytt`.
* `Dockerfile.amd64`: Added command to copy `/tmp/ytt` from the builder stage to `/usr/local/bin/ytt` in the final image.
* `Dockerfile.arm64`: Added commands to download `ytt`, make it executable, and move it to `/tmp/ytt`.
* `Dockerfile.arm64`: Added command to copy `/tmp/ytt` from the builder stage to `/usr/local/bin/ytt` in the final image.