### PR TITLE
feat: add argocd cli

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -22,6 +22,10 @@ RUN curl -LO https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.51.
     chmod +x ytt-linux-amd64 && \
     mv ytt-linux-amd64 /tmp/ytt
 
+RUN curl -LO https://github.com/argoproj/argo-cd/releases/download/v2.13.2/argocd-linux-amd64 && \
+    chmod +x argocd-linux-amd64 && \
+    mv argocd-linux-amd64 /tmp/argocd
+
 COPY ./entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 
@@ -38,6 +42,7 @@ COPY --from=builder /tmp/doctl /usr/local/bin/doctl
 COPY --from=builder /tmp/kubectl /usr/local/bin/kubectl
 COPY --from=builder /tmp/helm /usr/local/bin/helm
 COPY --from=builder /tmp/ytt /usr/local/bin/ytt
+COPY --from=builder /tmp/argocd /usr/local/bin/argocd
 COPY --from=builder /tmp/entrypoint.sh /entrypoint.sh
 
 RUN touch /etc/tracker-tv-do.conf

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -22,6 +22,10 @@ RUN curl -LO https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.51.
     chmod +x ytt-linux-arm64 && \
     mv ytt-linux-arm64 /tmp/ytt
 
+RUN curl -LO https://github.com/argoproj/argo-cd/releases/download/v2.13.2/argocd-linux-arm64 && \
+    chmod +x argocd-linux-arm64 && \
+    mv argocd-linux-arm64 /tmp/argocd
+
 COPY ./entrypoint.sh /tmp/entrypoint.sh
 RUN chmod +x /tmp/entrypoint.sh
 
@@ -38,6 +42,7 @@ COPY --from=builder /tmp/doctl /usr/local/bin/doctl
 COPY --from=builder /tmp/kubectl /usr/local/bin/kubectl
 COPY --from=builder /tmp/helm /usr/local/bin/helm
 COPY --from=builder /tmp/ytt /usr/local/bin/ytt
+COPY --from=builder /tmp/argocd /usr/local/bin/argocd
 COPY --from=builder /tmp/entrypoint.sh /entrypoint.sh
 
 RUN touch /etc/tracker-tv-do.conf

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This is the Digital Ocean image, it's intended to be used as a helper image for 
 
 ## Tools
 
+- `curl`
 - `jq`
 - `git`
+- `argocd`
 - `doctl`
 - `kubectl`
 - `helm`


### PR DESCRIPTION
This pull request includes updates to the Dockerfiles for both amd64 and arm64 architectures to add Argo CD, as well as documentation updates in the `README.md` file.

### Dockerfile Updates:

* `Dockerfile.amd64`: Added commands to download, set permissions, and move the `argocd` binary to `/tmp/argocd`. Also updated to copy `argocd` from the builder stage to `/usr/local/bin/argocd`.
* `Dockerfile.arm64`: Added commands to download, set permissions, and move the `argocd` binary to `/tmp/argocd`. Also updated to copy `argocd` from the builder stage to `/usr/local/bin/argocd`.

### Documentation Update:

* `README.md`: Added `argocd` to the list of tools.